### PR TITLE
修复了无法获取Launch文件中设置的参数的Bug

### DIFF
--- a/include/aimibot/odometry.hpp
+++ b/include/aimibot/odometry.hpp
@@ -23,7 +23,7 @@ namespace Aimi {
 class Odometry {
 public:
   Odometry();
-  void init(ros::NodeHandle& nh, const std::string& name);
+  void init(ros::NodeHandle& nh,ros::NodeHandle& nh_p, const std::string& name);
   bool commandTimeout() const;
   void update(const ecl::LegacyPose2D<double> &pose_update, ecl::linear_algebra::Vector3d &pose_update_rates,
               double imu_heading, double imu_angular_velocity);

--- a/launch/test.launch
+++ b/launch/test.launch
@@ -1,7 +1,11 @@
 <launch>
 
   <node pkg="aimibot" type="aimibot" name="aimibot" output="screen">
-    <param name="serial_port" value="/dev/ttyUSB0"/>
+    <param name="serial_port"     value="/dev/ttyUSB0"/>
+    <param name="odom_frame"      value="odom"/>
+    <param name="base_frame"      value="base_footprint"/>
+    <param name="use_imu_heading" value="true" />
+    <param name="publish_tf"      value="true" />
   </node>
 
 </launch>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -197,6 +197,8 @@ int main(int argc, char** argv)
     ros::init(argc, argv, "serial_port"); 
     //创建句柄（虽然后面没用到这个句柄，但如果不创建，运行时进程会出错）
     ros::NodeHandle nh;
+    ros::NodeHandle nh_p("~");
+
     Aimi::Odometry odometry;
     signal(SIGINT, shutdown);
     advertiseTopics(nh);
@@ -236,7 +238,7 @@ int main(int argc, char** argv)
     uint8_t temp_buffer[256];
     uint8_t buffer[256];
     uint8_t i =0;
-    odometry.init(nh,"aimibot");
+    odometry.init(nh,nh_p,"aimibot");
     reset_odometry();
     bool head_init = false;
     

--- a/src/odometry.cpp
+++ b/src/odometry.cpp
@@ -13,25 +13,25 @@ Odometry::Odometry():
   publish_tf(true)
 {};
 
-void Odometry::init(ros::NodeHandle& nh, const std::string& name) {
+void Odometry::init(ros::NodeHandle& nh,ros::NodeHandle& nh_p, const std::string& name) {
   double timeout;
-  nh.param("cmd_vel_timeout", timeout, 0.6);
+  nh_p.param("cmd_vel_timeout", timeout, 0.6);
   cmd_vel_timeout.fromSec(timeout);
   ROS_INFO_STREAM("Aimibot : Velocity commands timeout: " << cmd_vel_timeout << " seconds [" << name << "].");
 
-  if (!nh.getParam("odom_frame", odom_frame)) {
+  if (!nh_p.getParam("odom_frame", odom_frame)) {
     ROS_WARN_STREAM("Aimibot : no param server setting for odom_frame, using default [" << odom_frame << "][" << name << "].");
   } else {
     ROS_INFO_STREAM("Aimibot : using odom_frame [" << odom_frame << "][" << name << "].");
   }
 
-  if (!nh.getParam("base_frame", base_frame)) {
+  if (!nh_p.getParam("base_frame", base_frame)) {
     ROS_WARN_STREAM("Aimibot : no param server setting for base_frame, using default [" << base_frame << "][" << name << "].");
   } else {
     ROS_INFO_STREAM("Aimibot : using base_frame [" << base_frame << "][" << name << "].");
   }
 
-  if (!nh.getParam("publish_tf", publish_tf)) {
+  if (!nh_p.getParam("publish_tf", publish_tf)) {
     ROS_WARN_STREAM("Aimibot : no param server setting for publish_tf, using default [" << publish_tf << "][" << name << "].");
   } else {
     if ( publish_tf ) {
@@ -41,7 +41,7 @@ void Odometry::init(ros::NodeHandle& nh, const std::string& name) {
     }
   }
 
-  if (!nh.getParam("use_imu_heading", use_imu_heading)) {
+  if (!nh_p.getParam("use_imu_heading", use_imu_heading)) {
     ROS_WARN_STREAM("Aimibot : no param server setting for use_imu_heading, using default [" << use_imu_heading << "][" << name << "].");
   } else {
     if ( use_imu_heading ) {


### PR DESCRIPTION
添加了一个私有句柄，并且修改了所对应的Odometry::init()函数，可以正常获取launch文件中所设置的参数。